### PR TITLE
CrossSlideHorizontallyProperty and MSIX packaging

### DIFF
--- a/Demo/DemoApp/DemoApp.csproj
+++ b/Demo/DemoApp/DemoApp.csproj
@@ -15,7 +15,7 @@
         <LangVersion>latest</LangVersion>
         <ImplicitUsings>enable</ImplicitUsings>
         <RootNamespace>DemoApp</RootNamespace>
-        <WindowsPackageType>None</WindowsPackageType>
+        <WindowsPackageType>MSIX</WindowsPackageType>
 
         <!-- Display name -->
         <ApplicationTitle>Gestures Demo</ApplicationTitle>

--- a/Demo/DemoApp/Platforms/Windows/Package.appxmanifest
+++ b/Demo/DemoApp/Platforms/Windows/Package.appxmanifest
@@ -4,7 +4,9 @@
   xmlns:uap="http://schemas.microsoft.com/appx/manifest/uap/windows10"
   xmlns:mp="http://schemas.microsoft.com/appx/2014/phone/manifest"
   xmlns:rescap="http://schemas.microsoft.com/appx/manifest/foundation/windows10/restrictedcapabilities"
-  IgnorableNamespaces="uap rescap">
+  xmlns:com="http://schemas.microsoft.com/appx/manifest/com/windows10"
+  xmlns:desktop="http://schemas.microsoft.com/appx/manifest/desktop/windows10"
+  IgnorableNamespaces="uap rescap com desktop">
 
   <Identity Name="maui-package-name-placeholder" Publisher="CN=User Name" Version="0.0.0.0" />
 
@@ -36,6 +38,23 @@
         <uap:DefaultTile Square71x71Logo="$placeholder$.png" Wide310x150Logo="$placeholder$.png" Square310x310Logo="$placeholder$.png" />
         <uap:SplashScreen Image="$placeholder$.png" />
       </uap:VisualElements>
+      <Extensions>
+
+        <!--Specify which CLSID to activate when notification is clicked-->
+        <desktop:Extension Category="windows.toastNotificationActivation">
+          <desktop:ToastNotificationActivation ToastActivatorCLSID="6e919706-2634-4d97-a93c-2213b2acc334" />
+        </desktop:Extension>
+
+        <!--Register COM CLSID-->
+        <com:Extension Category="windows.comServer">
+          <com:ComServer>
+            <com:ExeServer Executable="DemoApp\DemoApp.exe" DisplayName="$targetnametoken$" Arguments="----AppNotificationActivated:">
+              <com:Class Id="6e919706-2634-4d97-a93c-2213b2acc334" />
+            </com:ExeServer>
+          </com:ComServer>
+        </com:Extension>
+
+      </Extensions>
     </Application>
   </Applications>
 

--- a/Demo/DemoApp/Properties/launchSettings.json
+++ b/Demo/DemoApp/Properties/launchSettings.json
@@ -1,9 +1,9 @@
 {
-  "$schema": "https://json.schemastore.org/launchsettings.json",
   "profiles": {
     "Windows Machine": {
-      "commandName": "Project",
+      "commandName": "MsixPackage",
       "nativeDebugging": false
     }
-  }
+  },
+  "$schema": "https://json.schemastore.org/launchsettings.json"
 }

--- a/MauiGestures/Gesture.cs
+++ b/MauiGestures/Gesture.cs
@@ -44,16 +44,22 @@ public static class Gesture
     /// </summary>
     public static readonly BindableProperty PanPointCommandProperty = BindableProperty.CreateAttached("PanPointCommand", typeof(ICommand), typeof(Gesture), null, propertyChanged: CommandChanged);
     public static readonly BindableProperty IsPanImmediateProperty = BindableProperty.CreateAttached("IsPanImmediate", typeof(bool), typeof(Gesture), false, propertyChanged: CommandChanged);
-   
+
+#if ANDROID
     /// <summary>
     /// Android only: min distance to trigger a swipe
     /// </summary>
     public static readonly BindableProperty SwipeThresholdProperty = BindableProperty.CreateAttached("SwipeThreshold", typeof(int), typeof(Gesture), 40, propertyChanged: CommandChanged);
+#endif
+
     public static readonly BindableProperty CommandParameterProperty = BindableProperty.CreateAttached("CommandParameter", typeof(object), typeof(Gesture), null);
 
+#if WINDOWS
     //Windows only
-    public static readonly BindableProperty ReturnAllPointsOnWindowsProperty = BindableProperty.CreateAttached("ReturnAllPointsOnWindows", typeof(bool), typeof(Gesture), false, propertyChanged: CommandChanged);
-    
+    public static readonly BindableProperty ProcessIntermediatePointsProperty = BindableProperty.CreateAttached("ProcessIntermediatePoints", typeof(bool), typeof(Gesture), false, propertyChanged: CommandChanged);
+    public static readonly BindableProperty CrossSlideHorizontallyProperty = BindableProperty.CreateAttached("CrossSlideHorizontally", typeof(bool), typeof(Gesture), true, propertyChanged: CommandChanged);
+#endif
+
     public static ICommand GetLongPressCommand(BindableObject view) => (ICommand)view.GetValue(LongPressCommandProperty);
     public static ICommand GetTapCommand(BindableObject view) => (ICommand)view.GetValue(TapCommandProperty);
     public static ICommand GetDoubleTapCommand(BindableObject view) => (ICommand)view.GetValue(DoubleTapCommandProperty);
@@ -82,9 +88,11 @@ public static class Gesture
     /// Take a (Point,GestureStatus) parameter (it is a tuple) 
     /// </summary>
     public static ICommand GetPanPointCommand(BindableObject view) => (ICommand)view.GetValue(PanPointCommandProperty);
-    
-    
-    public static bool GetReturnAllPointsOnWindows(BindableObject view) => (bool)view.GetValue(ReturnAllPointsOnWindowsProperty);
+
+#if WINDOWS
+    public static bool GetProcessIntermediatePoints(BindableObject view) => (bool)view.GetValue(ProcessIntermediatePointsProperty);
+    public static bool GetCrossSlideHorizontally(BindableObject view) => (bool)view.GetValue(CrossSlideHorizontallyProperty);
+#endif
 
     public static void SetLongPressCommand(BindableObject view, ICommand value) => view.SetValue(LongPressCommandProperty, value);
     public static void SetTapCommand(BindableObject view, ICommand value) => view.SetValue(TapCommandProperty, value);
@@ -114,8 +122,10 @@ public static class Gesture
     /// </summary>
     public static void SetPanPointCommand(BindableObject view, ICommand value) => view.SetValue(PanPointCommandProperty, value);
 
+#if ANDROID
     public static int GetSwipeThreshold(BindableObject view) => (int)view.GetValue(SwipeThresholdProperty);
     public static void SetSwipeThreshold(BindableObject view, int value) => view.SetValue(SwipeThresholdProperty, value);
+#endif
 
     public static object GetCommandParameter(BindableObject view) => view.GetValue(CommandParameterProperty);
     public static void SetCommandParameter(BindableObject view, object value) => view.SetValue(CommandParameterProperty, value);

--- a/MauiGestures/Gesture.cs
+++ b/MauiGestures/Gesture.cs
@@ -45,20 +45,15 @@ public static class Gesture
     public static readonly BindableProperty PanPointCommandProperty = BindableProperty.CreateAttached("PanPointCommand", typeof(ICommand), typeof(Gesture), null, propertyChanged: CommandChanged);
     public static readonly BindableProperty IsPanImmediateProperty = BindableProperty.CreateAttached("IsPanImmediate", typeof(bool), typeof(Gesture), false, propertyChanged: CommandChanged);
 
-#if ANDROID
     /// <summary>
     /// Android only: min distance to trigger a swipe
     /// </summary>
-    public static readonly BindableProperty SwipeThresholdProperty = BindableProperty.CreateAttached("SwipeThreshold", typeof(int), typeof(Gesture), 40, propertyChanged: CommandChanged);
-#endif
+    public static readonly BindableProperty AndroidSwipeThresholdProperty = BindableProperty.CreateAttached("SwipeThreshold", typeof(int), typeof(Gesture), 40, propertyChanged: CommandChanged);
 
     public static readonly BindableProperty CommandParameterProperty = BindableProperty.CreateAttached("CommandParameter", typeof(object), typeof(Gesture), null);
 
-#if WINDOWS
-    //Windows only
-    public static readonly BindableProperty ProcessIntermediatePointsProperty = BindableProperty.CreateAttached("ProcessIntermediatePoints", typeof(bool), typeof(Gesture), false, propertyChanged: CommandChanged);
-    public static readonly BindableProperty CrossSlideHorizontallyProperty = BindableProperty.CreateAttached("CrossSlideHorizontally", typeof(bool), typeof(Gesture), true, propertyChanged: CommandChanged);
-#endif
+    public static readonly BindableProperty WindowsProcessIntermediatePointsProperty = BindableProperty.CreateAttached("WindowsProcessIntermediatePoints", typeof(bool), typeof(Gesture), false, propertyChanged: CommandChanged);
+    public static readonly BindableProperty WindowsCrossSlideHorizontallyProperty = BindableProperty.CreateAttached("WindowsCrossSlideHorizontally", typeof(bool), typeof(Gesture), true, propertyChanged: CommandChanged);
 
     public static ICommand GetLongPressCommand(BindableObject view) => (ICommand)view.GetValue(LongPressCommandProperty);
     public static ICommand GetTapCommand(BindableObject view) => (ICommand)view.GetValue(TapCommandProperty);
@@ -89,10 +84,8 @@ public static class Gesture
     /// </summary>
     public static ICommand GetPanPointCommand(BindableObject view) => (ICommand)view.GetValue(PanPointCommandProperty);
 
-#if WINDOWS
-    public static bool GetProcessIntermediatePoints(BindableObject view) => (bool)view.GetValue(ProcessIntermediatePointsProperty);
-    public static bool GetCrossSlideHorizontally(BindableObject view) => (bool)view.GetValue(CrossSlideHorizontallyProperty);
-#endif
+    public static bool GetWindowsProcessIntermediatePoints(BindableObject view) => (bool)view.GetValue(WindowsProcessIntermediatePointsProperty);
+    public static bool GetWindowsCrossSlideHorizontally(BindableObject view) => (bool)view.GetValue(WindowsCrossSlideHorizontallyProperty);
 
     public static void SetLongPressCommand(BindableObject view, ICommand value) => view.SetValue(LongPressCommandProperty, value);
     public static void SetTapCommand(BindableObject view, ICommand value) => view.SetValue(TapCommandProperty, value);
@@ -122,10 +115,8 @@ public static class Gesture
     /// </summary>
     public static void SetPanPointCommand(BindableObject view, ICommand value) => view.SetValue(PanPointCommandProperty, value);
 
-#if ANDROID
-    public static int GetSwipeThreshold(BindableObject view) => (int)view.GetValue(SwipeThresholdProperty);
-    public static void SetSwipeThreshold(BindableObject view, int value) => view.SetValue(SwipeThresholdProperty, value);
-#endif
+    public static int GetAndroidSwipeThreshold(BindableObject view) => (int)view.GetValue(AndroidSwipeThresholdProperty);
+    public static void SetAndroidSwipeThreshold(BindableObject view, int value) => view.SetValue(AndroidSwipeThresholdProperty, value);
 
     public static object GetCommandParameter(BindableObject view) => view.GetValue(CommandParameterProperty);
     public static void SetCommandParameter(BindableObject view, object value) => view.SetValue(CommandParameterProperty, value);

--- a/MauiGestures/Lib/PlatformGestureEffect.cs
+++ b/MauiGestures/Lib/PlatformGestureEffect.cs
@@ -33,7 +33,7 @@ internal partial class PlatformGestureEffect : PlatformEffect
     private ICommand? pinchCommand;
 
 #if WINDOWS
-    private bool returnAllPointsOnWindows;
+    private bool processIntermediatePoints;
 #endif
 
     protected override void OnElementPropertyChanged(PropertyChangedEventArgs args)
@@ -62,7 +62,8 @@ internal partial class PlatformGestureEffect : PlatformEffect
             commandParameter = Gesture.GetCommandParameter(element);
 
 #if WINDOWS
-            returnAllPointsOnWindows = Gesture.GetReturnAllPointsOnWindows(element);
+            processIntermediatePoints = Gesture.GetProcessIntermediatePoints(element);
+            detector.CrossSlideHorizontally = Gesture.GetCrossSlideHorizontally(element);
 #endif
 
 #if IOS || MACCATALYST

--- a/MauiGestures/Lib/PlatformGestureEffect.cs
+++ b/MauiGestures/Lib/PlatformGestureEffect.cs
@@ -62,8 +62,8 @@ internal partial class PlatformGestureEffect : PlatformEffect
             commandParameter = Gesture.GetCommandParameter(element);
 
 #if WINDOWS
-            processIntermediatePoints = Gesture.GetProcessIntermediatePoints(element);
-            detector.CrossSlideHorizontally = Gesture.GetCrossSlideHorizontally(element);
+            processIntermediatePoints = Gesture.GetWindowsProcessIntermediatePoints(element);
+            detector.CrossSlideHorizontally = Gesture.GetWindowsCrossSlideHorizontally(element);
 #endif
 
 #if IOS || MACCATALYST

--- a/MauiGestures/Platforms/Windows/PlatformGestureEffect.cs
+++ b/MauiGestures/Platforms/Windows/PlatformGestureEffect.cs
@@ -238,7 +238,7 @@ internal partial class PlatformGestureEffect : PlatformEffect
 
     private void ControlOnPointerMoved(object sender, PointerRoutedEventArgs args)
     {
-        var points = returnAllPointsOnWindows ? args.GetIntermediatePoints(Control ?? Container) : [args.GetCurrentPoint(Control ?? Container)];
+        var points = processIntermediatePoints ? args.GetIntermediatePoints(Control ?? Container) : [args.GetCurrentPoint(Control ?? Container)];
 
         if (_currentPointer1 == null || points[0].Timestamp > _currentPointer1.Timestamp)
         {


### PR DESCRIPTION
Added the Windows-only CrossSlideHorizontallyProperty.  This allows an element to define whether swipes are either horizontal or vertical on Windows, since Windows only allows one or the other.

For the demo app, the appxmanifest needed to be updated (as per https://learn.microsoft.com/en-us/dotnet/communitytoolkit/maui/alerts/snackbar?tabs=windows%2Candroid) to get toasts/snackbars working fully on Windows 11.  In addition to that, the Windows app package must be an MSIX in order to ensure they work properly on Win 11.

Renamed ReturnAllPointsOnWindows to ProcessIntermediatePoints.  Up for debate if you don't want to change a previously published API.  I just find this is more descriptive.